### PR TITLE
Fix incrementing patch on RC versions producing an existing tag (#1)

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var patchRC bool
+
 // patchCmd represents the patch command
 var patchCmd = &cobra.Command{
 	Use:   "patch",
@@ -20,7 +22,10 @@ var patchCmd = &cobra.Command{
 			panic(err)
 		}
 		latestVersion := versions[0]
-		newVersion := latestVersion.IncrementPatch()
+		var newVersion = latestVersion.IncrementPatch()
+		if patchRC {
+			newVersion = latestVersion.IncrementPrerelease()
+		}
 		fmt.Println("Incrementing " + latestVersion.String() + " to " + newVersion.String())
 
 		if !dryRun {
@@ -36,6 +41,8 @@ var patchCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(patchCmd)
+
+	patchCmd.Flags().BoolVar(&patchRC, "rc", false, "Increment the release candidate (prerelease) instead of the patch version")
 
 	// Here you will define your flags and configuration settings.
 

--- a/core/version.go
+++ b/core/version.go
@@ -1,6 +1,11 @@
 package core
 
-import "github.com/Masterminds/semver"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
 
 type Version struct {
 	semverVersion *semver.Version
@@ -25,9 +30,56 @@ func (v Version) IncrementMinor() *Version {
 	return &Version{semverVersion: &newVersion}
 }
 
+// IncrementPatch produces the next patch release.
+//
+// semver's IncPatch keeps the patch number when the current version carries a
+// prerelease (e.g. v28.3.1-rc2000.1.0 -> v28.3.1), which collides with the
+// already released version it is a prerelease of. To avoid re-emitting an
+// existing tag we finalise a prerelease to the *next* patch release instead
+// (v28.3.1-rc2000.1.0 -> v28.3.2).
 func (v Version) IncrementPatch() *Version {
-	newVersion := v.semverVersion.IncPatch()
+	sv := v.semverVersion
+	if sv.Prerelease() != "" {
+		released, _ := sv.SetPrerelease("")
+		newVersion := released.IncPatch()
+		return &Version{semverVersion: &newVersion}
+	}
+	newVersion := sv.IncPatch()
 	return &Version{semverVersion: &newVersion}
+}
+
+// IncrementPrerelease produces the next release candidate.
+//
+// When the current version already carries a prerelease its trailing numeric
+// identifier is incremented (v28.3.1-rc2000.1.0 -> v28.3.1-rc2000.1.1). When it
+// does not, a fresh release candidate is started for the next patch release
+// (v28.3.1 -> v28.3.2-rc.0).
+func (v Version) IncrementPrerelease() *Version {
+	sv := v.semverVersion
+	pre := sv.Prerelease()
+
+	if pre == "" {
+		next := sv.IncPatch()
+		withPre, _ := next.SetPrerelease("rc.0")
+		return &Version{semverVersion: &withPre}
+	}
+
+	newVersion, _ := sv.SetPrerelease(incrementPrerelease(pre))
+	return &Version{semverVersion: &newVersion}
+}
+
+// incrementPrerelease bumps the last dot-separated numeric identifier of a
+// prerelease string. If no trailing numeric identifier exists a ".1" is
+// appended so the result still sorts after the current version.
+func incrementPrerelease(pre string) string {
+	identifiers := strings.Split(pre, ".")
+	for i := len(identifiers) - 1; i >= 0; i-- {
+		if n, err := strconv.Atoi(identifiers[i]); err == nil {
+			identifiers[i] = strconv.Itoa(n + 1)
+			return strings.Join(identifiers, ".")
+		}
+	}
+	return pre + ".1"
 }
 
 func (v Version) String() string {

--- a/core/version_test.go
+++ b/core/version_test.go
@@ -11,6 +11,16 @@ func mustVersion(t *testing.T, v string) *Version {
 	return version
 }
 
+// assertGreater fails if next is not strictly greater than current per semver
+// precedence. Every increment must move forward: the reported bug was an
+// increment that produced an already-existing, lower-or-equal version.
+func assertGreater(t *testing.T, current, next *Version) {
+	t.Helper()
+	if !next.semverVersion.GreaterThan(current.semverVersion) {
+		t.Errorf("expected %s to be strictly greater than %s", next, current)
+	}
+}
+
 func TestIncrementPatch(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -18,19 +28,67 @@ func TestIncrementPatch(t *testing.T) {
 		want    string
 	}{
 		{"plain patch bump", "v28.3.1", "v28.3.2"},
+		{"zero patch", "v1.0.0", "v1.0.1"},
 		// Regression test for https://github.com/Wulfheart/release-ranger/issues/1:
 		// a prerelease must finalise to the next patch, not to the already
 		// existing v28.3.1 that it is a prerelease of.
 		{"prerelease finalises to next patch", "v28.3.1-rc2000.1.0", "v28.3.2"},
 		{"simple prerelease", "v1.2.3-rc.0", "v1.2.4"},
+		{"prerelease with build metadata", "v1.2.3-rc.0+build.5", "v1.2.4"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mustVersion(t, tt.current).IncrementPatch().String()
-			if got != tt.want {
+			current := mustVersion(t, tt.current)
+			next := current.IncrementPatch()
+			if got := next.String(); got != tt.want {
 				t.Errorf("IncrementPatch(%q) = %q, want %q", tt.current, got, tt.want)
 			}
+			assertGreater(t, current, next)
+		})
+	}
+}
+
+func TestIncrementMinor(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		want    string
+	}{
+		{"plain minor bump resets patch", "v28.3.1", "v28.4.0"},
+		{"prerelease bumps to clean minor", "v28.3.1-rc2000.1.0", "v28.4.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := mustVersion(t, tt.current)
+			next := current.IncrementMinor()
+			if got := next.String(); got != tt.want {
+				t.Errorf("IncrementMinor(%q) = %q, want %q", tt.current, got, tt.want)
+			}
+			assertGreater(t, current, next)
+		})
+	}
+}
+
+func TestIncrementMajor(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		want    string
+	}{
+		{"plain major bump resets minor and patch", "v28.3.1", "v29.0.0"},
+		{"prerelease bumps to clean major", "v28.3.1-rc2000.1.0", "v29.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := mustVersion(t, tt.current)
+			next := current.IncrementMajor()
+			if got := next.String(); got != tt.want {
+				t.Errorf("IncrementMajor(%q) = %q, want %q", tt.current, got, tt.want)
+			}
+			assertGreater(t, current, next)
 		})
 	}
 }
@@ -43,16 +101,23 @@ func TestIncrementPrerelease(t *testing.T) {
 	}{
 		{"bump trailing identifier", "v28.3.1-rc2000.1.0", "v28.3.1-rc2000.1.1"},
 		{"bump single identifier", "v1.2.3-rc.0", "v1.2.3-rc.1"},
+		// Numeric identifiers are compared numerically, not lexically, so
+		// rc.9 -> rc.10 must still sort forward (asserted below).
+		{"numeric identifier past nine", "v1.2.3-rc.9", "v1.2.3-rc.10"},
+		{"numeric only prerelease", "v1.2.3-1", "v1.2.3-2"},
+		{"bumps last numeric identifier", "v1.2.3-alpha.2.beta", "v1.2.3-alpha.3.beta"},
 		{"append when no numeric identifier", "v1.2.3-rc", "v1.2.3-rc.1"},
 		{"start rc from a release", "v28.3.1", "v28.3.2-rc.0"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mustVersion(t, tt.current).IncrementPrerelease().String()
-			if got != tt.want {
+			current := mustVersion(t, tt.current)
+			next := current.IncrementPrerelease()
+			if got := next.String(); got != tt.want {
 				t.Errorf("IncrementPrerelease(%q) = %q, want %q", tt.current, got, tt.want)
 			}
+			assertGreater(t, current, next)
 		})
 	}
 }

--- a/core/version_test.go
+++ b/core/version_test.go
@@ -49,50 +49,6 @@ func TestIncrementPatch(t *testing.T) {
 	}
 }
 
-func TestIncrementMinor(t *testing.T) {
-	tests := []struct {
-		name    string
-		current string
-		want    string
-	}{
-		{"plain minor bump resets patch", "v28.3.1", "v28.4.0"},
-		{"prerelease bumps to clean minor", "v28.3.1-rc2000.1.0", "v28.4.0"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			current := mustVersion(t, tt.current)
-			next := current.IncrementMinor()
-			if got := next.String(); got != tt.want {
-				t.Errorf("IncrementMinor(%q) = %q, want %q", tt.current, got, tt.want)
-			}
-			assertGreater(t, current, next)
-		})
-	}
-}
-
-func TestIncrementMajor(t *testing.T) {
-	tests := []struct {
-		name    string
-		current string
-		want    string
-	}{
-		{"plain major bump resets minor and patch", "v28.3.1", "v29.0.0"},
-		{"prerelease bumps to clean major", "v28.3.1-rc2000.1.0", "v29.0.0"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			current := mustVersion(t, tt.current)
-			next := current.IncrementMajor()
-			if got := next.String(); got != tt.want {
-				t.Errorf("IncrementMajor(%q) = %q, want %q", tt.current, got, tt.want)
-			}
-			assertGreater(t, current, next)
-		})
-	}
-}
-
 func TestIncrementPrerelease(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/core/version_test.go
+++ b/core/version_test.go
@@ -1,0 +1,58 @@
+package core
+
+import "testing"
+
+func mustVersion(t *testing.T, v string) *Version {
+	t.Helper()
+	version, err := createVersion(v)
+	if err != nil {
+		t.Fatalf("createVersion(%q) returned error: %v", v, err)
+	}
+	return version
+}
+
+func TestIncrementPatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		want    string
+	}{
+		{"plain patch bump", "v28.3.1", "v28.3.2"},
+		// Regression test for https://github.com/Wulfheart/release-ranger/issues/1:
+		// a prerelease must finalise to the next patch, not to the already
+		// existing v28.3.1 that it is a prerelease of.
+		{"prerelease finalises to next patch", "v28.3.1-rc2000.1.0", "v28.3.2"},
+		{"simple prerelease", "v1.2.3-rc.0", "v1.2.4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mustVersion(t, tt.current).IncrementPatch().String()
+			if got != tt.want {
+				t.Errorf("IncrementPatch(%q) = %q, want %q", tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIncrementPrerelease(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		want    string
+	}{
+		{"bump trailing identifier", "v28.3.1-rc2000.1.0", "v28.3.1-rc2000.1.1"},
+		{"bump single identifier", "v1.2.3-rc.0", "v1.2.3-rc.1"},
+		{"append when no numeric identifier", "v1.2.3-rc", "v1.2.3-rc.1"},
+		{"start rc from a release", "v28.3.1", "v28.3.2-rc.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mustVersion(t, tt.current).IncrementPrerelease().String()
+			if got != tt.want {
+				t.Errorf("IncrementPrerelease(%q) = %q, want %q", tt.current, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #1.

Running `rer patch` on a release-candidate tag panics:

```
→ rer patch
Incrementing v28.3.1-rc2000.1.0 to v28.3.1
panic: exit status 128
```

`Masterminds/semver`'s `IncPatch()` **keeps** the patch number when the current version carries a prerelease (it just strips the prerelease). So `v28.3.1-rc2000.1.0` becomes `v28.3.1` — the already-released version the RC is a prerelease of — and `git tag` fails with exit 128 because the tag already exists.

## Fix

As suggested in the issue, `patch` now defaults to the next patch release and gains an opt-in flag for continuing the RC:

- **Default** — `IncrementPatch` finalises a prerelease to the *next* patch release, so it never re-emits an existing tag:
  `v28.3.1-rc2000.1.0` → `v28.3.2`
- **`--rc`** — continues the release candidate by bumping its trailing numeric identifier:
  `v28.3.1-rc2000.1.0` → `v28.3.1-rc2000.1.1`

Non-prerelease versions are unchanged (`v28.3.1` → `v28.3.2`), and `minor`/`major` were already unaffected.

## Verification

Added `core/version_test.go` covering both increment paths (including the exact issue scenario). End-to-end against a repo tagged `v28.3.1` + `v28.3.1-rc2000.1.0`:

```
$ rer patch --dry-run
Incrementing v28.3.1-rc2000.1.0 to v28.3.2
$ rer patch --rc --dry-run
Incrementing v28.3.1-rc2000.1.0 to v28.3.1-rc2000.1.1
```

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)