### PR TITLE
Fix macOS release binaries crashing on Apple Silicon (missing LC_UUID)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,14 +78,30 @@ jobs:
           cache: true
 
       - name: Build
-        run: go build --ldflags "-X 'github.com/wulfheart/release-ranger/cmd.version=$CURRENT_VERSION' -X 'github.com/wulfheart/release-ranger/cmd.goversion=$GOVERSION' -X 'github.com/wulfheart/release-ranger/cmd.commit=$GIT_COMMIT' -X 'github.com/wulfheart/release-ranger/cmd.built=$CURRENT_DATE' -X 'github.com/wulfheart/release-ranger/cmd.build=$BUILD'" -o rer
+        # -B gobuildid forces the linker to emit an LC_UUID load command.
+        # Without it these binaries lack LC_UUID and dyld aborts them on
+        # Apple Silicon with "missing LC_UUID load command". CGO_ENABLED=0
+        # gives a deterministic pure-Go cross-build (the tool has no cgo deps).
+        run: go build --ldflags "-B gobuildid -X 'github.com/wulfheart/release-ranger/cmd.version=$CURRENT_VERSION' -X 'github.com/wulfheart/release-ranger/cmd.goversion=$GOVERSION' -X 'github.com/wulfheart/release-ranger/cmd.commit=$GIT_COMMIT' -X 'github.com/wulfheart/release-ranger/cmd.built=$CURRENT_DATE' -X 'github.com/wulfheart/release-ranger/cmd.build=$BUILD'" -o rer
         env:
           GOOS: darwin
           BUILD: macos-${{ matrix.arch }}
           GOARCH: ${{ matrix.arch }}
+          CGO_ENABLED: 0
           GIT_COMMIT: ${{ github.sha }}
           CURRENT_DATE: ${{ github.event.repository.pushed_at }}
           GOVERSION: ${{ steps.setup-go.outputs.go-version }}
+
+      # Ad-hoc sign so the binary runs on Apple Silicon (the internal linker
+      # only auto-signs arm64, not amd64) and re-establishes a valid signature
+      # after the ldflags-driven build.
+      - name: Ad-hoc code sign
+        run: codesign --force --sign - rer
+
+      - name: Verify LC_UUID and signature
+        run: |
+          otool -l rer | grep -q LC_UUID || { echo "::error::binary is missing LC_UUID"; exit 1; }
+          codesign --verify --verbose rer
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
## Problem

The macOS binaries attached to releases (e.g. `rer-macos-arm64-v0.2.2`) abort immediately on Apple Silicon:

```
$ rer version
dyld[66041]: missing LC_UUID load command in .../rer-macos-arm64-v0.2.2
dyld[66041]: missing LC_UUID load command
[1]    66041 abort      release-ranger version
```

`otool -l` confirms the shipped binary has **no `LC_UUID`** load command. The Go linker only emits `LC_UUID` when a build ID is set, and the release build didn't set one — so dyld on macOS 13+ (Ventura and later) refuses to load it. This affects every user who downloads the macOS assets.

## Fix

In the `build-macos` job:

- **`-B gobuildid`** in the ldflags — forces the linker to emit an `LC_UUID` load command (the actual root-cause fix).
- **`CGO_ENABLED=0`** — deterministic pure-Go cross-build; the tool has no cgo dependencies, so this removes the runner-toolchain/external-linker variability that made the arm64 cross-build fragile.
- **Ad-hoc `codesign`** — the internal linker only auto-signs `arm64`; this ensures `amd64` is signed too and re-establishes a valid signature after the build.
- **Verification step** — fails the build if `LC_UUID` is absent or the signature doesn't verify, so a broken binary can never ship silently again.

## Verification

Built locally with the exact new ldflags for both target arches:

| target | LC_UUID | `codesign --verify` | runs |
|---|---|---|---|
| darwin/arm64 | ✅ | ✅ | ✅ (prints version) |
| darwin/amd64 | ✅ | ✅ | n/a (cross) |

The Linux build is intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)