### PR TITLE
Build macOS binaries with Go 1.23 (fix -B gobuildid on Go 1.21)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,10 @@ jobs:
         id: setup-go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          # Go >= 1.23 is required: the internal linker only emits an LC_UUID
+          # load command (and accepts -B gobuildid) from 1.23 onwards. On 1.21
+          # the build fails with "-B argument must start with 0x: gobuildid".
+          go-version: "1.23"
           cache: true
 
       - name: Build


### PR DESCRIPTION
## Problem

The release pipeline fails on the macOS build (introduced together with the LC_UUID fix):

```
link: -B argument must start with 0x: gobuildid
```

The `build-macos` job uses `-B gobuildid` to make the linker emit an `LC_UUID` load command, but the job is pinned to **Go 1.21**. The `gobuildid` special value — and internal-linker `LC_UUID` emission on darwin — were only added in **Go 1.23**. On 1.21 the linker only accepts a raw `0x…` hex value, so the build aborts.

## Fix

Bump the macOS build to Go 1.23. One line; everything else from the LC_UUID fix stays as-is.

## Verification

Tested on both the failing and fixed toolchains locally (Apple Silicon):

- **Go 1.21** — reproduces the exact failure (`-B argument must start with 0x`), and confirmed that even when it builds without `-B`, the internal linker emits **no** `LC_UUID` (which is why ≥1.23 is required).
- **Go 1.23** — full job sequence (build → `codesign --force --sign -` → verify) passes for **darwin/amd64** and **darwin/arm64**: `LC_UUID` present, `codesign --verify` passes, and the arm64 binary runs and prints its version.

Sorry for the churn — the original PR was validated on Go 1.23 locally but the CI pins 1.21, which I should have matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)